### PR TITLE
Refactor

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,15 +1,17 @@
 {
-    "extends": "airbnb-base",
-    "plugins": [
-        "import"
-    ],
-    "rules": {
-        "arrow-parens": ["error", "as-needed", { "requireForBlockBody": false }],
-        "consistent-return": ["off"],
-        "prefer-rest-params": ["off"],
-        "no-else-return": ["off"],
-        "no-param-reassign": ["off"],
-        "no-restricted-syntax": ["off"],
-        "no-underscore-dangle": ["off", { "allowAfterThis": true, "allowAfterSuper": true }]
-    }
+  "extends": "airbnb-base",
+  "plugins": [
+    "import"
+  ],
+  "parser": "babel-eslint",
+  "rules": {
+    "arrow-parens": ["error", "as-needed", { "requireForBlockBody": false }],
+    "consistent-return": ["off"],
+    "prefer-rest-params": ["off"],
+    "no-else-return": ["off"],
+    "no-param-reassign": ["off"],
+    "no-restricted-syntax": ["off"],
+    "no-underscore-dangle": ["off", { "allowAfterThis": true, "allowAfterSuper": true }],
+    "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }]
+  }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -21,6 +21,7 @@
     "no-plusplus": ["off"],
     "react/jsx-filename-extension": ["error", { "extensions": [".js", ".jsx"] }],
     "react/prefer-stateless-function": ["off"],
-    "class-methods-use-this": ["off"]
+    "class-methods-use-this": ["off"],
+    "react/no-multi-comp": ["off"]
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,12 @@
 {
-  "extends": "airbnb-base",
+  "extends": "airbnb",
+  "env": {
+      "browser": true,
+      "node": true
+  },
   "plugins": [
+    "react",
+    "jsx-a11y",
     "import"
   ],
   "parser": "babel-eslint",
@@ -12,6 +18,9 @@
     "no-param-reassign": ["off"],
     "no-restricted-syntax": ["off"],
     "no-underscore-dangle": ["off", { "allowAfterThis": true, "allowAfterSuper": true }],
-    "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }]
+    "no-plusplus": ["off"],
+    "react/jsx-filename-extension": ["error", { "extensions": [".js", ".jsx"] }],
+    "react/prefer-stateless-function": ["off"],
+    "class-methods-use-this": ["off"]
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,5 @@ addons:
       - ubuntu-toolchain-r-test
     packages:
       - g++-4.8
+before_script:
+  - "npm install react"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A simple top down data flow implementation for React",
   "main": "dist/index.js",
   "scripts": {
+    "prepublish": "npm run build",
     "lint": "eslint src/ test/",
     "lint:watch": "esw src/ test/ -w",
     "ava": "ava test/ --verbose",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "ava": {
     "babel": "inherit",
     "require": [
-      "babel-register"
+      "babel-register",
+      "./test/helpers/setup-test-env.js"
     ]
   },
   "repository": {
@@ -62,10 +63,17 @@
     "babel-preset-stage-0": "^6.22.0",
     "babel-register": "^6.24.0",
     "concurrently": "^3.4.0",
+    "enzyme": "^2.8.0",
     "eslint": "^3.19.0",
     "eslint-config-airbnb-base": "^11.1.2",
     "eslint-plugin-import": "^2.2.0",
-    "eslint-watch": "^3.0.1"
+    "eslint-plugin-jsx-a11y": "^4.0.0",
+    "eslint-plugin-react": "^6.10.3",
+    "eslint-watch": "^3.0.1",
+    "jsdom": "^9.12.0",
+    "react": "^15.5.3",
+    "react-addons-test-utils": "^15.5.0",
+    "react-dom": "^15.5.3"
   },
   "peerDependencies": {
     "react": ">=15.3.0"

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "eslint-plugin-react": "^6.10.3",
     "eslint-watch": "^3.0.1",
     "jsdom": "^9.12.0",
+    "prop-types": "^15.5.7",
     "react": "^15.5.3",
     "react-addons-test-utils": "^15.5.0",
     "react-dom": "^15.5.3"

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "concurrently": "^3.4.0",
     "enzyme": "^2.8.0",
     "eslint": "^3.19.0",
-    "eslint-config-airbnb-base": "^11.1.2",
+    "eslint-config-airbnb": "^14.1.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^4.0.0",
     "eslint-plugin-react": "^6.10.3",

--- a/package.json
+++ b/package.json
@@ -49,11 +49,13 @@
   "dependencies": {
     "@noflux/state": "^0.1.1",
     "pure-render-decorator": "^1.2.1",
+    "rxjs": "^5.3.0",
     "semver": "^5.3.0"
   },
   "devDependencies": {
     "ava": "^0.18.2",
     "babel-cli": "^6.24.0",
+    "babel-eslint": "^7.2.1",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-preset-es2015": "^6.24.0",
     "babel-preset-react": "^6.23.0",

--- a/src/connect.js
+++ b/src/connect.js
@@ -1,0 +1,82 @@
+import { Observable } from 'rxjs/Observable';
+import { from } from 'rxjs/observable/from';
+import { mergeMap } from 'rxjs/operator/mergeMap';
+import { share } from 'rxjs/operator/share';
+import state from './state';
+import {
+  __DEV__,
+  timer,
+  isString,
+  isReactComponent,
+  isReactPureComponent,
+  override,
+  getComponentName,
+} from './utils';
+
+const connectWrapper = (Component, pathArray = ['']) => {
+  for (let i = 0; i < pathArray.length; i++) {
+    const path = pathArray[i];
+    if (!isString(path) && !Array.isArray(path)) {
+      throw new TypeError('@connect(path1, path2, ...) every path must be String or Array');
+    }
+  }
+  if (Component.__noflux) {
+    throw new SyntaxError(`You should not use @connect for component ${getComponentName(Component)} more than once, use @connect(path1, path2, ...) instead`);
+  }
+  Component.__noflux = {};
+
+  const change$ = Observable
+    ::from(pathArray)
+    ::mergeMap(path => state.cursor(path).listen('change'))
+    ::share();
+
+  override(Component, 'componentDidMount', originComponentDidMount => function componentDidMount() {
+    this.__noflux = {};
+    this.__noflux.subscription = change$
+      .subscribe({
+        next: () => {
+          if (__DEV__) {
+            this.__noflux.timers = {
+              startUpdate: timer.now(),
+            };
+          }
+          this.forceUpdate(() => {
+            if (__DEV__) {
+              this.__noflux.timers.endUpdate = timer.now();
+              const cost = this.__noflux.timers.endUpdate - this.__noflux.timers.startUpdate;
+              // eslint-disable-next-line no-console
+              console.log(`[noflux] ${getComponentName(Component)} rendering time ${cost.toFixed(3)} ms`);
+            }
+          });
+        },
+      });
+    if (originComponentDidMount) {
+      originComponentDidMount.call(this);
+    }
+  });
+
+  override(Component, 'componentWillUnmount', originComponentWillUnmount => function componentWillUnmount() {
+    this.__noflux.subscription.unsubscribe();
+    if (originComponentWillUnmount) {
+      originComponentWillUnmount.call(this);
+    }
+  });
+
+  return Component;
+};
+
+const connect = (...args) => {
+  if (!args.length) {
+    throw new TypeError('@connect() is invalid, do you mean @connect or @connect(\'\') or @connect([]) ?');
+  }
+  const [Component] = args;
+  if (isReactPureComponent(Component)) {
+    throw new TypeError('@connect should not be used for PureComponent');
+  } else if (isReactComponent(Component)) {
+    return connectWrapper(Component);
+  } else {
+    return realComponent => connectWrapper(realComponent, args);
+  }
+};
+
+export default connect;

--- a/src/connect.js
+++ b/src/connect.js
@@ -16,12 +16,11 @@ import {
 } from './utils';
 
 const connectWrapper = (Component, cursorPaths = ['']) => {
-  for (let i = 0; i < cursorPaths.length; i++) {
-    const path = cursorPaths[i];
+  cursorPaths.forEach(path => {
     if (!isString(path) && !Array.isArray(path)) {
       throw new TypeError('@connect(path1, path2, ...) every path must be String or Array.');
     }
-  }
+  });
   if (Component.__noflux) {
     throw new SyntaxError(`You should not use @connect for component ${getComponentName(Component)} more than once, use @connect(path1, path2, ...) instead.`);
   }

--- a/src/connect.js
+++ b/src/connect.js
@@ -19,11 +19,11 @@ const connectWrapper = (Component, cursorPaths = ['']) => {
   for (let i = 0; i < cursorPaths.length; i++) {
     const path = cursorPaths[i];
     if (!isString(path) && !Array.isArray(path)) {
-      throw new TypeError('@connect(path1, path2, ...) every path must be String or Array');
+      throw new TypeError('@connect(path1, path2, ...) every path must be String or Array.');
     }
   }
   if (Component.__noflux) {
-    throw new SyntaxError(`You should not use @connect for component ${getComponentName(Component)} more than once, use @connect(path1, path2, ...) instead`);
+    throw new SyntaxError(`You should not use @connect for component ${getComponentName(Component)} more than once, use @connect(path1, path2, ...) instead.`);
   }
   Component.__noflux = {};
 
@@ -69,13 +69,13 @@ const connectWrapper = (Component, cursorPaths = ['']) => {
 
 const verifyReactImpureComponent = (target, prop, descriptor) => {
   if (isReactComponentInstance(target) && prop && descriptor) {
-    throw new SyntaxError('@connect should not be used for component method');
+    throw new SyntaxError('@connect should not be used for component method.');
   }
   if (isReactStatelessComponent(target)) {
-    throw new TypeError('@connect should not be used for stateless component');
+    throw new TypeError('@connect should not be used for stateless component.');
   }
   if (isReactPureComponent(target)) {
-    throw new TypeError('@connect should not be used for pure component');
+    throw new TypeError('@connect should not be used for pure component.');
   }
   if (isReactComponent(target)) {
     return true;
@@ -86,12 +86,12 @@ const verifyReactImpureComponent = (target, prop, descriptor) => {
 const connectWithCursor = cursorPaths => (...args) => {
   const [target, prop, descriptor] = args;
   if (!target) {
-    throw new TypeError('connect(path1, path2, ...)() is invalid, the param component must be given');
+    throw new TypeError('connect(path1, path2, ...)() is invalid, the param component must be given.');
   }
   if (verifyReactImpureComponent(target, prop, descriptor)) {
     connectWrapper(target, cursorPaths);
   } else {
-    throw new TypeError('@connect must be used for component');
+    throw new TypeError('@connect must be used for component.');
   }
 };
 
@@ -105,6 +105,17 @@ const connect = (...args) => {
   } else {
     return connectWithCursor(args);
   }
+};
+
+let noticed = false;
+
+export const Connect = (...args) => {
+  if (!noticed) {
+    noticed = true;
+    // eslint-disable-next-line no-console
+    console.warn('@Connect is deprecated, use @connect instead.');
+  }
+  return connect(...args);
 };
 
 export default connect;

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
-import { State } from '@noflux/state';
-import state from './state';
+import state, { State } from './state';
 import pure from './pure';
 import connect, { Connect } from './connect';
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,11 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { State } from '@noflux/state';
+import state from './state';
 import pure from './pure';
+import connect from './connect';
 
 export {
-  pure,
   State,
+  state,
+  pure,
+  connect,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,12 @@
 import { State } from '@noflux/state';
 import state from './state';
 import pure from './pure';
-import connect from './connect';
+import connect, { Connect } from './connect';
 
 export {
   State,
   state,
   pure,
   connect,
+  Connect,
 };

--- a/src/pure.js
+++ b/src/pure.js
@@ -19,7 +19,7 @@ const checkPureDeprecated = () => {
 
 let noticed = false;
 
-export default component => {
+const pure = component => {
   if (!noticed) {
     noticed = true;
     const pureDeprecated = checkPureDeprecated();
@@ -30,3 +30,5 @@ export default component => {
   }
   return pureRender(component);
 };
+
+export default pure;

--- a/src/state.js
+++ b/src/state.js
@@ -1,0 +1,5 @@
+import { State } from '@noflux/state';
+
+const state = new State();
+
+export default state;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,34 @@
+export const __DEV__ = process.env.NODE_ENV !== 'production';
+
+/* global performance */
+export const timer = (
+  typeof performance !== 'undefined'
+  && performance
+  && performance.now
+  ? performance : Date
+);
+
+export const isString = str => typeof str === 'string';
+
+export const isReactComponent = Component =>
+  Component.prototype && Component.prototype.isReactComponent;
+
+export const isReactPureComponent = Component =>
+  Component.prototype && Component.prototype.isPureReactComponent;
+
+export const getComponentName = Component => {
+  const constructor = Component.prototype && Component.prototype.constructor;
+  return (
+    Component.displayName
+    || (constructor && constructor.displayName)
+    || Component.name
+    || (constructor && constructor.name)
+    || 'NONAME'
+  );
+};
+
+export function noop() {}
+
+export const override = (Class, methodName, callback) => {
+  Class.prototype[methodName] = callback(Class.prototype[methodName]);
+};

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,10 +11,16 @@ export const timer = (
 export const isString = str => typeof str === 'string';
 
 export const isReactComponent = Component =>
-  Component.prototype && Component.prototype.isReactComponent;
+  Component && Component.prototype && Component.prototype.isReactComponent;
 
 export const isReactPureComponent = Component =>
-  Component.prototype && Component.prototype.isPureReactComponent;
+  Component && Component.prototype && Component.prototype.isPureReactComponent;
+
+export const isReactStatelessComponent = Component =>
+  typeof Component === 'function' && !isReactComponent(Component);
+
+export const isReactComponentInstance = instance =>
+  instance && Object.getPrototypeOf(instance) && Object.getPrototypeOf(instance).isReactComponent;
 
 export const getComponentName = Component => {
   const constructor = Component.prototype && Component.prototype.constructor;
@@ -26,8 +32,6 @@ export const getComponentName = Component => {
     || 'NONAME'
   );
 };
-
-export function noop() {}
 
 export const override = (Class, methodName, callback) => {
   Class.prototype[methodName] = callback(Class.prototype[methodName]);

--- a/test/connect/bad-usage.js
+++ b/test/connect/bad-usage.js
@@ -1,0 +1,23 @@
+import test from 'ava';
+import React, { Component } from 'react';
+import { mount } from 'enzyme';
+import { connect } from '../../src';
+
+test('can not use @connect for pure component', t => {
+  t.throws(() => {
+    class App extends Component {
+      @connect
+      render() {
+        return (
+          <h1>
+            {this.props.text}
+          </h1>
+        );
+      }
+    }
+    App.propTypes = {
+      text: React.PropTypes.string.isRequired,
+    };
+    mount(<App text="hello, world" />);
+  });
+});

--- a/test/connect/bad-usage.js
+++ b/test/connect/bad-usage.js
@@ -1,5 +1,6 @@
 import test from 'ava';
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { mount } from 'enzyme';
 import { connect } from '../../src';
 
@@ -16,7 +17,7 @@ test('can not use @connect for pure component', t => {
       }
     }
     App.propTypes = {
-      text: React.PropTypes.string.isRequired,
+      text: PropTypes.string.isRequired,
     };
     mount(<App text="hello, world" />);
   });

--- a/test/connect/component.js
+++ b/test/connect/component.js
@@ -1,0 +1,25 @@
+import test from 'ava';
+import React, { Component } from 'react';
+import { mount } from 'enzyme';
+import { connect, state } from '../../src';
+
+test('make the component fluxify', t => {
+  state.set({ name: 'Ssnau' });
+
+  @connect
+  class App extends Component {
+    render() {
+      return (
+        <h1 id={state.get('name')}>
+          {state.get('name')}
+        </h1>
+      );
+    }
+  }
+  const wrapper = mount(<App />);
+  t.is(wrapper.find('h1').props().id, 'Ssnau');
+  t.is(wrapper.find('h1').text(), 'Ssnau');
+  state.set({ name: 'Malash' });
+  t.is(wrapper.find('h1').props().id, 'Malash');
+  t.is(wrapper.find('h1').text(), 'Malash');
+});

--- a/test/connect/component.js
+++ b/test/connect/component.js
@@ -6,9 +6,11 @@ import { connect, state } from '../../src';
 test('make the component fluxify', t => {
   state.set({ name: 'Ssnau' });
 
+  let renderCallTimes = 0;
   @connect
   class App extends Component {
     render() {
+      renderCallTimes++;
       return (
         <h1 id={state.get('name')}>
           {state.get('name')}
@@ -19,7 +21,9 @@ test('make the component fluxify', t => {
   const wrapper = mount(<App />);
   t.is(wrapper.find('h1').props().id, 'Ssnau');
   t.is(wrapper.find('h1').text(), 'Ssnau');
+  t.is(renderCallTimes, 1);
   state.set({ name: 'Malash' });
   t.is(wrapper.find('h1').props().id, 'Malash');
   t.is(wrapper.find('h1').text(), 'Malash');
+  t.is(renderCallTimes, 2);
 });

--- a/test/connect/connect-deprecated.js
+++ b/test/connect/connect-deprecated.js
@@ -1,0 +1,25 @@
+import test from 'ava';
+import React, { Component } from 'react';
+import { mount } from 'enzyme';
+import { Connect, state } from '../../src';
+
+test('@Connect deprecated', t => {
+  state.set({ name: 'Ssnau' });
+
+  @Connect
+  class App extends Component {
+    render() {
+      return (
+        <h1 id={state.get('name')}>
+          {state.get('name')}
+        </h1>
+      );
+    }
+  }
+  const wrapper = mount(<App />);
+  t.is(wrapper.find('h1').props().id, 'Ssnau');
+  t.is(wrapper.find('h1').text(), 'Ssnau');
+  state.set({ name: 'Malash' });
+  t.is(wrapper.find('h1').props().id, 'Malash');
+  t.is(wrapper.find('h1').text(), 'Malash');
+});

--- a/test/connect/partial-connect.js
+++ b/test/connect/partial-connect.js
@@ -1,0 +1,68 @@
+import test from 'ava';
+import React, { Component } from 'react';
+import { mount } from 'enzyme';
+import { connect, state } from '../../src';
+
+test('partial connect', t => {
+  state.set({
+    profile: {
+      name: 'Ssnau',
+    },
+    repo: {
+      name: 'noflux',
+    },
+  });
+
+  let profileRenderCallTimes = 0;
+  @connect('profile')
+  class ProfleContainer extends Component {
+    render() {
+      profileRenderCallTimes++;
+      return (
+        <div>
+          Profile name is {state.get('profile.name')}
+        </div>
+      );
+    }
+  }
+
+  let repoRenderCallTimes = 0;
+  @connect('repo.name')
+  class RepoContainer extends Component {
+    render() {
+      repoRenderCallTimes++;
+      return (
+        <div>
+          Repo name is {state.get('repo.name')}
+        </div>
+      );
+    }
+  }
+
+  class App extends Component {
+    render() {
+      return (
+        <div>
+          <ProfleContainer />
+          <RepoContainer />
+        </div>
+      );
+    }
+  }
+
+  mount(<App />);
+  t.is(profileRenderCallTimes, 1);
+  t.is(repoRenderCallTimes, 1);
+
+  state.set('profile.name', 'Malash');
+  t.is(profileRenderCallTimes, 2);
+  t.is(repoRenderCallTimes, 1);
+
+  state.set('repo.name', '@noflux/react');
+  t.is(profileRenderCallTimes, 2);
+  t.is(repoRenderCallTimes, 2);
+
+  state.set('repo.git', 'https://github.com/nofluxjs/react.git');
+  t.is(profileRenderCallTimes, 2);
+  t.is(repoRenderCallTimes, 2);
+});

--- a/test/connect/pure-component.js
+++ b/test/connect/pure-component.js
@@ -1,0 +1,21 @@
+import test from 'ava';
+import React, { PureComponent } from 'react';
+import { connect } from '../../src';
+
+test('can not use @connect for pure component', t => {
+  t.throws(() => {
+    @connect
+    class App extends PureComponent {
+      render() {
+        return (
+          <h1>
+            {this.props.text}
+          </h1>
+        );
+      }
+    }
+    App.propTypes = {
+      text: React.PropTypes.string.isRequired,
+    };
+  });
+});

--- a/test/connect/pure-component.js
+++ b/test/connect/pure-component.js
@@ -1,5 +1,6 @@
 import test from 'ava';
 import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from '../../src';
 
 test('can not use @connect for pure component', t => {
@@ -15,7 +16,7 @@ test('can not use @connect for pure component', t => {
       }
     }
     App.propTypes = {
-      text: React.PropTypes.string.isRequired,
+      text: PropTypes.string.isRequired,
     };
   });
 });

--- a/test/connect/stateless-component.js
+++ b/test/connect/stateless-component.js
@@ -1,0 +1,19 @@
+import test from 'ava';
+import React from 'react';
+import { connect } from '../../src';
+
+test('can not use @connect for stateless component', t => {
+  t.throws(() => {
+    function App(props) {
+      return (
+        <h1>
+          {props.text}
+        </h1>
+      );
+    }
+    App.propTypes = {
+      text: React.PropTypes.string.isRequired,
+    };
+    connect(App);
+  });
+});

--- a/test/connect/stateless-component.js
+++ b/test/connect/stateless-component.js
@@ -1,5 +1,6 @@
 import test from 'ava';
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from '../../src';
 
 test('can not use @connect for stateless component', t => {
@@ -12,7 +13,7 @@ test('can not use @connect for stateless component', t => {
       );
     }
     App.propTypes = {
-      text: React.PropTypes.string.isRequired,
+      text: PropTypes.string.isRequired,
     };
     connect(App);
   });

--- a/test/helpers/setup-test-env.js
+++ b/test/helpers/setup-test-env.js
@@ -1,0 +1,5 @@
+import { jsdom } from 'jsdom';
+
+global.document = jsdom('<body></body>');
+global.window = document.defaultView;
+global.navigator = window.navigator;

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,0 @@
-import test from 'ava';
-
-test.todo('todo');

--- a/test/utils/component.js
+++ b/test/utils/component.js
@@ -2,7 +2,7 @@ import test from 'ava';
 import React, { Component } from 'react';
 import { isReactComponent, isReactPureComponent, getComponentName } from '../../src/utils';
 
-test('is react component', t => {
+test('check component', t => {
   class App extends Component {
     render() {
       return (

--- a/test/utils/component.js
+++ b/test/utils/component.js
@@ -1,0 +1,18 @@
+import test from 'ava';
+import React, { Component } from 'react';
+import { isReactComponent, isReactPureComponent, getComponentName } from '../../src/utils';
+
+test('is react component', t => {
+  class App extends Component {
+    render() {
+      return (
+        <h1>
+          hello, world
+        </h1>
+      );
+    }
+  }
+  t.truthy(isReactComponent(App));
+  t.falsy(isReactPureComponent(App));
+  t.is(getComponentName(App), 'App');
+});

--- a/test/utils/instance.js
+++ b/test/utils/instance.js
@@ -7,7 +7,7 @@ import {
   isReactComponentInstance,
 } from '../../src/utils';
 
-test('is react component instance', t => {
+test('check component instance', t => {
   class App extends Component {
     render() {
       return (

--- a/test/utils/instance.js
+++ b/test/utils/instance.js
@@ -1,0 +1,25 @@
+import test from 'ava';
+import React, { Component } from 'react';
+import {
+  isReactComponent,
+  isReactPureComponent,
+  isReactStatelessComponent,
+  isReactComponentInstance,
+} from '../../src/utils';
+
+test('is react component instance', t => {
+  class App extends Component {
+    render() {
+      return (
+        <h1>
+          hello, world
+        </h1>
+      );
+    }
+  }
+  const instance = new App();
+  t.falsy(isReactComponent(instance));
+  t.falsy(isReactPureComponent(instance));
+  t.falsy(isReactStatelessComponent(instance));
+  t.truthy(isReactComponentInstance(instance));
+});

--- a/test/utils/override.js
+++ b/test/utils/override.js
@@ -1,0 +1,30 @@
+import test from 'ava';
+import { override } from '../../src/utils';
+
+test('override', t => {
+  t.plan(4);
+  let count = 0;
+  class A {
+    run() {
+      t.is(count++, 2);
+    }
+    anotherRun() {
+      t.is(count++, 0);
+    }
+  }
+  class B extends A {
+    run() {
+      super.run();
+      t.is(count++, 3);
+    }
+  }
+  override(B, 'run', originRun => function run() {
+    this.anotherRun();
+    t.is(count++, 1);
+    if (originRun) {
+      originRun.call(this);
+    }
+  });
+  const obj = new B();
+  obj.run();
+});

--- a/test/utils/pure-component.js
+++ b/test/utils/pure-component.js
@@ -1,0 +1,18 @@
+import test from 'ava';
+import React, { PureComponent } from 'react';
+import { isReactComponent, isReactPureComponent, getComponentName } from '../../src/utils';
+
+test('is react pure component', t => {
+  class App extends PureComponent {
+    render() {
+      return (
+        <h1>
+          hello, world
+        </h1>
+      );
+    }
+  }
+  t.truthy(isReactComponent(App));
+  t.truthy(isReactPureComponent(App));
+  t.is(getComponentName(App), 'App');
+});

--- a/test/utils/pure-component.js
+++ b/test/utils/pure-component.js
@@ -2,7 +2,7 @@ import test from 'ava';
 import React, { PureComponent } from 'react';
 import { isReactComponent, isReactPureComponent, getComponentName } from '../../src/utils';
 
-test('is react pure component', t => {
+test('check pure component', t => {
   class App extends PureComponent {
     render() {
       return (


### PR DESCRIPTION
对整个项目进行了重构。

变化：

- `@connect('path.to.a', ['path', 'to', 'b'])` 支持部分监听功能
- `@connect`不再支持自定义`state`
- `@connect`其他功能向下兼容
- 添加对`PureComponent`和`StatelessFunctionalComponent`的判断
- `state`接口变更请参见 https://github.com/nofluxjs/state/pull/3
- 修复原`noflux`中`handler`作用域bug https://github.com/ssnau/noflux/issues/1
- `@Connect`给予废弃提示
- `@pure`低版本给予废弃提示，高版本（>=15.3）报错


未解决问题：

- 性能优化，避免无用重复渲染
- `@connect`传入自定义`state`需要报错
- 依赖`rxjs`，影响打包大小
- `@noflux/state`中对`rxjs`和`semver`依赖，影响打包大小
- `React`版本兼容性测试
- 功能测试不够完善