### PR TITLE
remove semver for less code size

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,7 @@
   "dependencies": {
     "@noflux/state": "^0.1.1",
     "pure-render-decorator": "^1.2.1",
-    "rxjs": "^5.3.0",
-    "semver": "^5.3.0"
+    "rxjs": "^5.3.0"
   },
   "devDependencies": {
     "ava": "^0.18.2",

--- a/src/pure.js
+++ b/src/pure.js
@@ -1,20 +1,13 @@
-import semver from 'semver';
 import pureRender from 'pure-render-decorator';
 
-const checkReactVersion = () => {
-  let reactVersion;
+const checkPureDeprecated = () => {
   try {
     // eslint-disable-next-line global-require, import/no-unresolved
-    reactVersion = require('react/package.json').version;
+    const React = require('react');
+    return Boolean(React.PureComponent);
   } catch (e) {
     throw new ReferenceError('React not installed');
   }
-  return reactVersion;
-};
-
-const checkPureDeprecated = () => {
-  const reactVersion = checkReactVersion();
-  return semver.gte(reactVersion, '15.3.0');
 };
 
 let noticed = false;


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/1812118/25241399/6c45c98e-2628-11e7-9f2a-80ffdba06a5a.png)

`semver` cost a quarter of bundle file size.