### PR TITLE
refact partial connect for a better paradigm

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "homepage": "https://github.com/nofluxjs/react#readme",
   "dependencies": {
-    "@noflux/state": "^0.4.0",
+    "@noflux/state": "^0.5.0",
     "pure-render-decorator": "^1.2.1"
   },
   "devDependencies": {

--- a/src/connect.js
+++ b/src/connect.js
@@ -2,7 +2,6 @@ import state from './state';
 import {
   __DEV__,
   timer,
-  isString,
   isReactComponent,
   isReactPureComponent,
   isReactStatelessComponent,
@@ -11,45 +10,59 @@ import {
   getComponentName,
 } from './utils';
 
-const connectWrapper = (Component, cursorPaths = ['']) => {
+const connectComponent = Component => {
   if (Component.__noflux) {
     throw new SyntaxError(`You should not use @connect for component ${getComponentName(Component)} more than once.`);
   }
   Component.__noflux = {};
 
-  const cursors = cursorPaths.map(cursorPath => {
-    if (!isString(cursorPath)) {
-      throw new TypeError('@connect([path1, path2, ...]) every path must be String.');
+  override(Component, 'componentWillMount', originComponentWillMount => function componentWillMount() {
+    // call origin componentWillMount
+    if (originComponentWillMount) {
+      originComponentWillMount.call(this);
     }
-    return state.cursor(cursorPath);
-  });
 
-  override(Component, 'componentDidMount', originComponentDidMount => function componentDidMount() {
-    this.__noflux = {};
-
+    // init
+    this.__noflux = {
+      getPaths: {},
+      onChangeHandlers: [],
+    };
     const cursorChange = () => {
       // skip change emitted after unmounting component
       // TODO: test this guard
       if (!this.__noflux.mounted) return;
 
-      if (__DEV__) {
-        this.__noflux.timers = {
-          startUpdate: timer.now(),
-        };
-      }
+      const startTime = timer.now();
       this.forceUpdate(() => {
+        const endTime = timer.now();
+        const cost = endTime - startTime;
         if (__DEV__) {
-          this.__noflux.timers.endUpdate = timer.now();
-          const cost = this.__noflux.timers.endUpdate - this.__noflux.timers.startUpdate;
           // eslint-disable-next-line no-console
           console.log(`[noflux] ${getComponentName(Component)} rendering time ${cost.toFixed(3)} ms`);
         }
       });
     };
+    this.__noflux.onGetHandler = state.on('get', ({ path }) => {
+      if (this.__noflux.isRendering && !this.__noflux.getPaths[path]) {
+        this.__noflux.getPaths[path] = true;
+        // register cursor change handler
+        this.__noflux.onChangeHandlers.push(state.cursor(path).on('change', cursorChange));
+      }
+    });
+  });
 
-    // register cursor change handlers
-    this.__noflux.cursorChangeHandlers = cursors.map(cursor => cursor.on('change', cursorChange));
+  override(Component, 'render', originRender => function render() {
+    if (!originRender) {
+      throw new Error(`No render method found on the returned component instance of ${getComponentName(Component)}, you may have forgotten to define render.`);
+    }
 
+    this.__noflux.isRendering = true;
+    const vdom = originRender.call(this);
+    this.__noflux.isRendering = false;
+    return vdom;
+  });
+
+  override(Component, 'componentDidMount', originComponentDidMount => function componentDidMount() {
     // call origin componentDidMount
     if (originComponentDidMount) {
       originComponentDidMount.call(this);
@@ -61,21 +74,27 @@ const connectWrapper = (Component, cursorPaths = ['']) => {
 
   override(Component, 'componentWillUnmount', originComponentWillUnmount => function componentWillUnmount() {
     // unregister cursor change handlers
-    this.__noflux.cursorChangeHandlers.forEach(handler => handler());
+    this.__noflux.onChangeHandlers.forEach(handler => handler());
+
+    // inregister on get handler
+    this.__noflux.onGetHandler();
+
+    // reset component mounted flag
+    this.__noflux.mounted = false;
 
     // call origin componentWillUnmount
     if (originComponentWillUnmount) {
       originComponentWillUnmount.call(this);
     }
-
-    // reset component mounted flag
-    this.__noflux.mounted = false;
   });
 
   return Component;
 };
 
-const verifyReactImpureComponent = (target, prop, descriptor) => {
+const connect = (target, prop, descriptor) => {
+  if (!target) {
+    throw new TypeError('@connect() is invalid, do you mean @connect or @connect(\'\') or @connect([]) ?');
+  }
   if (isReactComponentInstance(target) && prop && descriptor) {
     throw new SyntaxError('@connect should not be used for component method.');
   }
@@ -85,33 +104,10 @@ const verifyReactImpureComponent = (target, prop, descriptor) => {
   if (isReactPureComponent(target)) {
     throw new TypeError('@connect should not be used for pure component.');
   }
-  if (isReactComponent(target)) {
-    return true;
+  if (!isReactComponent(target)) {
+    throw new TypeError('@connect should be used for React component');
   }
-  return false;
-};
-
-const connectWithCursor = cursorPaths => (target, prop, descriptor) => {
-  if (!target) {
-    throw new TypeError('connect(...)() is invalid, the param component must be given.');
-  }
-  if (verifyReactImpureComponent(target, prop, descriptor)) {
-    connectWrapper(target, cursorPaths);
-  } else {
-    throw new TypeError('@connect must be used for component.');
-  }
-};
-
-const connect = (target, prop, descriptor) => {
-  if (!target) {
-    throw new TypeError('@connect() is invalid, do you mean @connect or @connect(\'\') or @connect([]) ?');
-  }
-  if (verifyReactImpureComponent(target, prop, descriptor)) {
-    return connectWrapper(target);
-  } else {
-    const cursorPaths = Array.isArray(target) ? target : [target];
-    return connectWithCursor(cursorPaths);
-  }
+  return connectComponent(target);
 };
 
 let noticed = false;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,5 @@
 export const __DEV__ = process.env.NODE_ENV !== 'production';
 
-export const SYMBOL_NOFLUX = '__noflux';
-
 /* global performance */
 export const timer = (
   typeof performance !== 'undefined'

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,7 @@
 export const __DEV__ = process.env.NODE_ENV !== 'production';
 
+export const SYMBOL_NOFLUX = '__noflux';
+
 /* global performance */
 export const timer = (
   typeof performance !== 'undefined'

--- a/src/utils.js
+++ b/src/utils.js
@@ -8,8 +8,6 @@ export const timer = (
   ? performance : Date
 );
 
-export const isString = str => typeof str === 'string';
-
 export const isReactComponent = Component =>
   Component && Component.prototype && Component.prototype.isReactComponent;
 

--- a/test/connect/partial-connect.js
+++ b/test/connect/partial-connect.js
@@ -14,7 +14,7 @@ test('partial connect', t => {
   });
 
   let profileRenderCallTimes = 0;
-  @connect('profile')
+  @connect
   class ProfileContainer extends Component {
     render() {
       profileRenderCallTimes++;
@@ -27,7 +27,7 @@ test('partial connect', t => {
   }
 
   let projectRenderCallTimes = 0;
-  @connect('project.name')
+  @connect
   class ProjectContainer extends Component {
     render() {
       projectRenderCallTimes++;
@@ -40,7 +40,7 @@ test('partial connect', t => {
   }
 
   let combineRenderCallTimes = 0;
-  @connect(['profile', 'project.name'])
+  @connect
   class CombineContainer extends Component {
     render() {
       combineRenderCallTimes++;
@@ -81,6 +81,11 @@ test('partial connect', t => {
   t.is(combineRenderCallTimes, 3);
 
   state.set('project.repo', 'https://github.com/nofluxjs/react.git');
+  t.is(profileRenderCallTimes, 2);
+  t.is(projectRenderCallTimes, 2);
+  t.is(combineRenderCallTimes, 3);
+
+  state.set('other', 'data');
   t.is(profileRenderCallTimes, 2);
   t.is(projectRenderCallTimes, 2);
   t.is(combineRenderCallTimes, 3);


### PR DESCRIPTION
# Features
By recording `get` event during `render` call, we can know which part of state changes will cause `forceUpdate` at next `render` call. So it's no need to specific `path` in `@connect` argument.

```js
@connect
class App extends Component {
  render() {
    // start recording
    return (
      <div>{state.get('data')}</div>
    );
    // stop recording, 'data' is needed
    // setTimeout(() => state.set('data', 'value'), 1000) will cause `App` re-rending
  }
}
```

# Breaking changes

It's a breaking change to `@noflux/react@0.3.0` but it is compatible with `noflux`.