### PR TITLE
Batch forceUpdate

### DIFF
--- a/src/connect.js
+++ b/src/connect.js
@@ -34,6 +34,8 @@ const connectComponent = Component => {
     this[SYMBOL_NOFLUX] = {
       getPaths: {},
       onChangeDisposers: [],
+      mounted: false,
+      isForcingUpdate: false,
     };
     const __noflux = this[SYMBOL_NOFLUX];
 
@@ -42,8 +44,14 @@ const connectComponent = Component => {
       // TODO: test this guard
       if (!__noflux.mounted) return;
 
+      // skip duplicate forceUpdate calling
+      if (__noflux.isForcingUpdate) return;
+      __noflux.isForcingUpdate = true;
+
       const startTime = timer.now();
       this.forceUpdate(() => {
+        __noflux.isForcingUpdate = false;
+
         const endTime = timer.now();
         const cost = endTime - startTime;
         if (__DEV__) {
@@ -65,7 +73,6 @@ const connectComponent = Component => {
     if (!originRender) {
       throw new Error(`No render method found on the returned component instance of ${getComponentName(Component)}, you may have forgotten to define render.`);
     }
-
     const __noflux = this[SYMBOL_NOFLUX];
     __noflux.isRendering = true;
     const vdom = originRender.call(this);

--- a/test/connect/batch-force-update.js
+++ b/test/connect/batch-force-update.js
@@ -1,0 +1,42 @@
+import test from 'ava';
+import '../helpers/setup-test-env';
+import React, { Component } from 'react';
+import { mount } from 'enzyme';
+import { connect, state } from '../../src';
+
+test('should batch forceUpdate', t => {
+  state.load({ name: 'Ssnau' });
+
+  let forceUpdateCallTimes = 0;
+  let renderCallTimes = 0;
+
+  @connect
+  class App extends Component {
+    onClick() {
+      for (let i = 0; i < 10; i++) {
+        state.set('name', `Malash${i}`);
+      }
+    }
+
+    forceUpdate(...args) {
+      super.forceUpdate(...args);
+      forceUpdateCallTimes++;
+    }
+
+    render() {
+      renderCallTimes++;
+      return (
+        <botton onClick={() => this.onClick()}>
+          {state.get('name')}
+        </botton>
+      );
+    }
+  }
+
+  const wrapper = mount(<App />);
+  wrapper.find('botton').simulate('click');
+
+  t.is(forceUpdateCallTimes, 1);
+  t.is(renderCallTimes, 2);
+  t.is(wrapper.find('botton').text(), 'Malash9');
+});


### PR DESCRIPTION
Although React already used `inst._reactInternalInstance._pendingForceUpdate` to batch `forceUpdate`, the `@connect` still call it more than once which making confusing output in `console.log` and consuming more computing resources.

![image](https://user-images.githubusercontent.com/1812118/30426780-e24b1d94-997f-11e7-80e9-d530a817bc98.png)
