### PR TITLE
Support React new lifecycle methods

### DIFF
--- a/src/connect.js
+++ b/src/connect.js
@@ -22,56 +22,52 @@ const connectComponent = Component => {
     return Component;
   }
 
-  override(Component, 'componentWillMount', originComponentWillMount => function componentWillMount() {
-    // call origin componentWillMount
-    if (originComponentWillMount) {
-      originComponentWillMount.call(this);
-    }
-
-    // init
-    this[SYMBOL_NOFLUX] = {
-      getPaths: {},
-      onChangeDisposers: [],
-      mounted: false,
-      isForcingUpdate: false,
-    };
-    const __noflux = this[SYMBOL_NOFLUX];
-
-    const cursorChange = () => {
-      // skip change emitted after unmounting component
-      // TODO: test this guard
-      if (!__noflux.mounted) return;
-
-      // skip duplicate forceUpdate calling
-      if (__noflux.isForcingUpdate) return;
-      __noflux.isForcingUpdate = true;
-
-      const startTime = timer.now();
-      this.forceUpdate(() => {
-        __noflux.isForcingUpdate = false;
-
-        const endTime = timer.now();
-        const cost = endTime - startTime;
-        if (__DEV__) {
-          // eslint-disable-next-line no-console
-          console.log(`[noflux] ${getComponentName(Component)} rendering time ${cost.toFixed(3)} ms`);
-        }
-      });
-    };
-    __noflux.onGetDisposer = state.on('get', ({ path }) => {
-      if (__noflux.isRendering && !__noflux.getPaths[path]) {
-        __noflux.getPaths[path] = true;
-        // register cursor change handler
-        __noflux.onChangeDisposers.push(state.cursor(path).on('change', cursorChange));
-      }
-    });
-  });
-
   override(Component, 'render', originRender => function render() {
     if (!originRender) {
       throw new Error(`No render method found on the returned component instance of ${getComponentName(Component)}, you may have forgotten to define render.`);
     }
-    const __noflux = this[SYMBOL_NOFLUX];
+
+    let __noflux = this[SYMBOL_NOFLUX];
+    if (!__noflux) {
+      // init
+      this[SYMBOL_NOFLUX] = {
+        getPaths: {},
+        onChangeDisposers: [],
+        mounted: false,
+        isForcingUpdate: false,
+      };
+      __noflux = this[SYMBOL_NOFLUX];
+
+      const cursorChange = () => {
+        // skip change emitted after unmounting component
+        // TODO: test this guard
+        if (!__noflux.mounted) return;
+
+        // skip duplicate forceUpdate calling
+        if (__noflux.isForcingUpdate) return;
+        __noflux.isForcingUpdate = true;
+
+        const startTime = timer.now();
+        this.forceUpdate(() => {
+          __noflux.isForcingUpdate = false;
+
+          const endTime = timer.now();
+          const cost = endTime - startTime;
+          if (__DEV__) {
+            // eslint-disable-next-line no-console
+            console.log(`[noflux] ${getComponentName(Component)} rendering time ${cost.toFixed(3)} ms`);
+          }
+        });
+      };
+      __noflux.onGetDisposer = state.on('get', ({ path }) => {
+        if (__noflux.isRendering && !__noflux.getPaths[path]) {
+          __noflux.getPaths[path] = true;
+          // register cursor change handler
+          __noflux.onChangeDisposers.push(state.cursor(path).on('change', cursorChange));
+        }
+      });
+    }
+
     __noflux.isRendering = true;
     const vdom = originRender.call(this);
     __noflux.isRendering = false;


### PR DESCRIPTION
As React 16.3 introducing [the new lifecycle api](https://reactjs.org/blog/2018/03/29/react-v-16-3.html), some old lifecycle methods were unsafe in `StrictMode` ( and will be removed in React 17 ).

The `connect` decorator used to hook `componentWillMount` method for listening initialization and would cause this warning.

![image](https://user-images.githubusercontent.com/1812118/38546490-6613d5dc-3cdf-11e8-980c-46f68541e59e.png)

I find a solution by moving initialization into the first function call of `render` inspired by [the example](https://github.com/reactjs/rfcs/blob/master/text/0006-static-lifecycle-methods.md#prefetching-async-data-during-mount) from  [React RFC 0006](https://github.com/reactjs/rfcs/blob/master/text/0006-static-lifecycle-methods.md) and it passed all tests.